### PR TITLE
Fix null deprecation error in PHP 8.1+

### DIFF
--- a/includes/EmbedSpotify.php
+++ b/includes/EmbedSpotify.php
@@ -16,7 +16,7 @@ class EmbedSpotify {
 	 * @return string
 	 */
 	public static function renderSpotify( $input, array $args, Parser $parser, PPFrame $frame ) {
-		$input = htmlspecialchars( $input );
+		$input = htmlspecialchars( $input ?? '' );
 		if ( empty( $args['width'] ) ) {
 			$args['width'] = '300px';
 		}


### PR DESCRIPTION
PHP 8.1+ complains that passing null to `htmlspecialchars()` is deprecated, therefore, if `$input` is null, pass an empty string to shut the linter up. 

Downstream task: https://issue-tracker.miraheze.org/T13423