### PR TITLE
Fix MW 1.44 compatibility

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -12,5 +12,8 @@
 	"AutoloadClasses": {
 		"EmbedSpotify": "includes/EmbedSpotify.php"
 	},
-	"manifest_version": 1
+	"manifest_version": 1,
+	"requires": {
+		"MediaWiki": ">= 1.40.0"
+	}
 }

--- a/includes/EmbedSpotify.php
+++ b/includes/EmbedSpotify.php
@@ -1,4 +1,7 @@
 <?php
+
+use MediaWiki\Html\Html;
+
 class EmbedSpotify {
 	/**
 	 * Bind the renderPoem function to the <spotify> tag
@@ -23,15 +26,13 @@ class EmbedSpotify {
 		if ( empty( $args['height'] ) ) {
 			$args['height'] = '380px';
 		}
-		$args['width'] = htmlspecialchars( $args['width'] );
-		$args['height'] = htmlspecialchars( $args['height'] );
-		return Html::rawElement( 'iframe', [
+		return Html::element( 'iframe', [
 			'src' => "https://open.spotify.com/embed/$input",
 			'width' => $args['width'],
 			'height' => $args['height'],
 			'frameborder' => '0',
 			'allowtransparency' => 'true',
 			'allow' => 'encrypted-media'
-		], '' );
+		] );
 	}
 }


### PR DESCRIPTION
* Add import for namespaced Html class since the class alias was removed in MW 1.44.
* Set MW requirement to 1.40 since the Html class was namespaced in that version
* Use Html::element instead of Html::rawElement since there is no content to escape
* Remove redundant htmlspecialchars since Html::element already escapes attributes sufficiently